### PR TITLE
Added an "onError" setting in the options object (issue #2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function gulpWatchifyBrowserify(globPattern, options, streamHandler, done) {
   options = merge.recursive({
     watch: process.env.NODE_ENV === 'development',
     cwd: process.cwd(),
+    onError: function(err){},
     browserify: {
       insertGlobals: false,
       cache: {},
@@ -119,6 +120,7 @@ function gulpWatchifyBrowserify(globPattern, options, streamHandler, done) {
               chalk.magenta(file),
               chalk.gray('(' + String(err) + ')')
             )));
+            options.onError.call(this, err);
             this.emit('end');
           })
           .pipe(source(file))


### PR DESCRIPTION
The current version of the plugin does not allow for custom error functionality.

This doesn't fix the issue of stream.on('error') not working but it at least provides a way for developers to run code that occurs when the Browserify bundler fails to compile.

So in the demo gulp file you can do this sort of thing:

``````js
/**
 * Browserify / Watchify task
 */
gulp.task('browserify', function(done) {

  var src = './src',
      dest = './dest';

  var options = {
    onError: function(error){
       console.log("Browserify has encountered an error:\n", error);
    },
    // watch mode
    watch: watch,
    // set cwd to manipulate relative output path
    cwd: src,
    browserify: {
      paths: [
        path.join(src, 'modules'),
        './node_modules'
      ],
      debug: true,
      transform: [
        eslintify,
        [uglifyify, {global: true}]
      ]
    }
  };

  gulpWB('*.js', options, streamHandler.bind(this), done);

  /**
   * stream handler to apply further gulp plugins
   * @param  {Object} stream  gulp file stream
   * @return {Object}         processed stream
   */
  function streamHandler(stream) {
    return stream
      .pipe(plumber())
      .pipe(sourcemaps.init({loadMaps: true}))
      .pipe(sourcemaps.write('.', {includeContent: true, sourceRoot: '.'}))
      .pipe(gulp.dest(dest));
  }

});
``````